### PR TITLE
Modify Dockerfile to work with legacy SSL authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,18 @@ WORKDIR /api/fastapi
 # Expose port for FastAPI app to run on
 EXPOSE 8000
 
+# Create OpenSSL conf file for OECD data access within openbb
+RUN echo 'openssl_conf = openssl_init\n\
+\n\
+[openssl_init]\n\
+ssl_conf = ssl_sect\n\
+\n\
+[ssl_sect]\n\
+system_default = system_default_sect\n\
+\n\
+[system_default_sect]\n\
+Options = UnsafeLegacyRenegotiation'\
+> /api/fastapi/openssl.cnf
+
 # Run the FastAPI app
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--env-file", ".env"]


### PR DESCRIPTION
Legacy SSL authentication is needed to retrieve OECD data when using openbb. This data includes macroeconomic metrics such as gross domestic product of countries.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Previous version of the Dockerfile did not work with OECD queries as the OECD server used in OpenBBTerminal only supports legacy SSL authentication. Therefore, a specific `openssl` configuration is needed.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
