### PR TITLE
Add OpenBB API keys loading at startup

### DIFF
--- a/gptstonks_api/main.py
+++ b/gptstonks_api/main.py
@@ -23,6 +23,7 @@ from .utils import (
     get_func_parameter_names,
     get_griffin_few_shot_template,
     get_griffin_general_template,
+    get_keys_file,
     get_wizardcoder_few_shot_template,
 )
 
@@ -104,6 +105,12 @@ def init_data():
     # For now all models use Griffin template, it should be simple enough
     general_template = get_griffin_general_template()
     app.get_answer = guidance_wrapper(general_template)
+
+    # Load API keys and set them in OpenBB
+    if os.path.exists(get_keys_file()):
+        with open(get_keys_file()) as keys_file:
+            keys_list = json.load(keys_file)
+        openbb.keys.set_keys(keys_dict=keys_list, persist=True, show_output=False)
 
 
 @app.post("/process_query_async")
@@ -232,7 +239,7 @@ async def set_api_keys(request: Request):
     show_output = data.get("show_output") or False
     if keys_list is not None:
         openbb.keys.set_keys(keys_dict=keys_list, persist=persist, show_output=show_output)
-        with open("./apikeys_list.json", "w") as keysFile:
+        with open(get_keys_file(), "w") as keysFile:
             json.dump(keys_list, keysFile)
         return {"status": "Keys set correctly", "keys": keys_list}
     else:

--- a/gptstonks_api/utils.py
+++ b/gptstonks_api/utils.py
@@ -103,3 +103,7 @@ def get_default_classifier_model():
 
 def get_default_llm():
     return "daedalus314/Griffin-3B-GPTQ"
+
+
+def get_keys_file():
+    return "./apikeys_list.json"


### PR DESCRIPTION
The JSON file with the API keys must exist so that it can be loaded. This method works only for a local deployment of the API.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Allows loading OpenBB API keys at startup time.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
