### PR TITLE
Modify API to work with AutoLlamaIndex

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
     hooks:
       - id: codespell
         args:
-          - --skip=logs/**,data/**,*.ipynb,poetry.lock
+          - --skip=logs/**,data/**,*.ipynb,poetry.lock,pdm.lock
           # - --ignore-words-list=abc,def
 
   # jupyter notebook cell output clearing

--- a/gptstonks_api/main.py
+++ b/gptstonks_api/main.py
@@ -3,13 +3,18 @@ import asyncio
 import json
 import os
 import uuid
+from functools import partial
 
 import pandas as pd
 import torch
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from openbb_chat.classifiers.stransformer import STransformerZeroshotClassifier
-from openbb_chat.llms.guidance_wrapper import GuidanceWrapper
+from langchain.agents import AgentType, Tool, initialize_agent
+from langchain.llms import OpenAI
+from langchain.tools import DuckDuckGoSearchRun
+from langchain.utilities import PythonREPL, SerpAPIWrapper
+from llama_index.indices.postprocessor import SimilarityPostprocessor
+from openbb_chat.kernels.auto_llama_index import AutoLlamaIndex
 from openbb_terminal.sdk import openbb
 from rich.progress import track
 from transformers import BitsAndBytesConfig, GPTQConfig
@@ -24,6 +29,8 @@ from .utils import (
     get_griffin_few_shot_template,
     get_griffin_general_template,
     get_keys_file,
+    get_openbb_chat_output,
+    get_openbb_chat_output_executed,
     get_wizardcoder_few_shot_template,
 )
 
@@ -32,9 +39,14 @@ GPTStonks API allows interacting with [OpenBB](https://openbb.co/) using natural
 
 # Features
 The API supports the following features:
-- All LLMs on [Hugging Face](https://huggingface.co/).
+- OpenAI LLMs.
 - Multiple text embedding models on Hugging Face.
 - Asynchronous processing.
+
+# API Operating Modes
+The API can operate in two modes:
+- **Programmer**: only OpenBB SDK is used to retrieve financial and economical data. It is the fastest and cheapest mode, but it is restricted to OpenBB SDK's functionalities.
+- **Agent**: different tools are used, including OpenBB SDK and DuckDuckGo, that can look for general information and specific financial data. It is slower and slightly more expensive than Programmer, but also more powerful.
 """
 
 app = FastAPI(
@@ -65,46 +77,59 @@ results_store = {}
 
 @app.on_event("startup")
 def init_data():
-    """Initial function called during the application startup.
+    """Initial function called during the application startup."""
 
-    It initializes the descriptions, definitions, classifiers, and templates for guidance.
-    """
-    df = pd.read_csv(get_definitions_path(), sep=get_definitions_sep())
-    df = df.dropna()
-    app.definitions = df["Definitions"].tolist()
-
-    with torch.inference_mode():
-        app.stransformer = STransformerZeroshotClassifier(
-            get_embeddings_path(),
-            os.environ.get("CLASSIFIER_MODEL", get_default_classifier_model()),
-        )
-
-    llm_kwargs = {
-        "device_map": {"": 0},
-    }
-    if "gptq" not in os.environ.get("LLM_MODEL", get_default_llm()).lower():
-        bnb_config = BitsAndBytesConfig(
-            load_in_4bit=True,
-            bnb_4bit_use_double_quant=True,
-            bnb_4bit_quant_type="nf4",
-            bnb_4bit_compute_dtype=torch.bfloat16,
-        )
-        llm_kwargs.update({"quantization_config": bnb_config})
-    guidance_wrapper = GuidanceWrapper(
-        model_id=os.environ.get("LLM_MODEL", get_default_llm()),
-        model_kwargs=llm_kwargs,
+    # Load AutoLlamaIndex
+    app.auto_llama_index = AutoLlamaIndex(
+        os.getenv("VSI_PATH"),
+        os.getenv("EMBEDDING_MODEL_ID", "local:BAAI/bge-large-en-v1.5"),
+        os.getenv("LLM_MODEL_ID", "openai:gpt-3.5-turbo"),
+        context_window=os.getenv("LLM_CONTEXT_WINDOW", 4096),
+        qa_template_str=os.getenv("QA_TEMPLATE", None),
+        refine_template_str=os.getenv("REFINE_TEMPLATE", None),
+        other_llama_index_vector_index_retriever_kwargs={
+            "similarity_top_k": os.getenv("VIR_SIMILARITY_TOP_K", 3)
+        },
+        other_llama_index_bm25_retriever_kwargs={
+            "similarity_top_k": os.getenv("BMR_SIMILARITY_TOP_K", 3)
+        },
     )
 
-    # Code template
-    code_template = get_wizardcoder_few_shot_template()
-    if "griffin" in os.environ.get("LLM_MODEL", get_default_llm()).lower():
-        code_template = get_griffin_few_shot_template()
-    app.get_code = guidance_wrapper(code_template)
-
-    # General knowledge template
-    # For now all models use Griffin template, it should be simple enough
-    general_template = get_griffin_general_template()
-    app.get_answer = guidance_wrapper(general_template)
+    # Create agent
+    search = DuckDuckGoSearchRun()
+    app.python_repl_utility = PythonREPL()
+    app.python_repl_utility.globals = globals()
+    partial_get_openbb_chat_output_executed = partial(
+        get_openbb_chat_output_executed,
+        auto_llama_index=app.auto_llama_index,
+        python_repl_utility=app.python_repl_utility,
+    )
+    app.tools = [
+        Tool(
+            name="Search",
+            func=search.run,
+            description=os.getenv("AGENT_SEARCH_TOOL_DESCRIPTION"),
+        ),
+        Tool(
+            name="OpenBBChat",
+            func=partial_get_openbb_chat_output_executed,
+            description=os.getenv("OPENBBCHAT_TOOL_DESCRIPTION"),
+            return_direct=True,
+        ),
+    ]
+    app.agent = initialize_agent(
+        tools=app.tools,
+        llm=OpenAI(
+            model_name=os.getenv("LLM_MODEL_ID", "openai:gpt-3.5-turbo").split(":")[1],
+            temperature=0,
+            request_timeout=os.getenv("AGENT_REQUEST_TIMEOUT", 20),
+        ),
+        agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+        verbose=True,
+        return_intermediate_steps=True,
+        max_iterations=2,
+        early_stopping_method=os.getenv("AGENT_EARLY_STOPPING_METHOD", "generate"),
+    )
 
     # Load API keys and set them in OpenBB
     if os.path.exists(get_keys_file()):
@@ -126,59 +151,74 @@ async def process_query_async(request: Request):
     """
     data = await request.json()
     query = data.get("query")
+    use_agent = data.get("use_agent", False)
 
     job_id = str(uuid.uuid4())
     response = {"message": "Processing started", "job_id": job_id}
 
-    asyncio.create_task(run_model_in_background(job_id, query))
+    asyncio.create_task(run_model_in_background(job_id, query, use_agent))
 
     return response
 
 
-async def run_model_in_background(job_id: str, query: str):
+async def run_model_in_background(job_id: str, query: str, use_agent: bool):
     """Background task to process the query using the STransformer and OpenBB. Stores the result in
     the global results_store dictionary.
 
     Args:
         job_id (str): Unique identifier for the job.
         query (str): User query to process.
+        use_agent (bool): Whether to run in Agent mode or Programmer mode.
 
     Returns:
         None
     """
-    with torch.inference_mode():
-        _, scores, indices = app.stransformer.rank_k(query, k=3)
-        if scores[0] < 0.45:
-            results_store[job_id] = {
-                "type": "general_response",
-                "body": app.get_answer(query=query)["answer"],
-            }
-            return
-        func_defs = [app.definitions[idx] for idx in indices]
-        func_names = [func_def.split("(")[0] for func_def in func_defs]
 
-        code = app.get_code(func_def=func_defs[0], func_name=func_names[0], query=query)
-        final_func_call = f"{func_names[0]}({code['params'].strip()})"
-
-    # Prevent memory leakage
-    torch.cuda.empty_cache()
-
-    # Call OpenBB SDK
     try:
-        res = eval(final_func_call)
-        if isinstance(res, pd.DataFrame):
-            res = res.dropna().to_dict(orient="dict")
-        elif res is None:
-            res = "Nothing returned."
-        elif isinstance(res, list):
-            res = pd.DataFrame(res).dropna().to_dict(orient="dict")
+        if use_agent:
+            # Run agent
+            agent_output = app.agent({"input": query})
+            print(f"{agent_output=}")
+            agent_output_str = agent_output["output"]
+
+            try:
+                res = json.loads(agent_output_str)
+                results_store[job_id] = {
+                    "type": "data",
+                    "result_data": res,
+                    "body": [
+                        [f"Observation {idx}: {step[1]}"]
+                        for idx, step in enumerate(agent_output["intermediate_steps"])
+                    ],
+                }
+            except Exception as e:
+                results_store[job_id] = {
+                    "type": "data",
+                    "body": [
+                        f"Observation {idx}: {step[1]}"
+                        for idx, step in enumerate(agent_output["intermediate_steps"])
+                    ]
+                    + [f"Final answer: {agent_output_str}"],
+                }
         else:
-            res = str(res)
-        results_store[job_id] = {
-            "type": "data",
-            "result_data": res,
-            "body": code["answer"],
-        }
+            # Run programmer
+            openbbchat_output = get_openbb_chat_output(
+                query_str=query, auto_llama_index=app.auto_llama_index
+            )
+            code_str = openbbchat_output.response.split("```python")[1].split("```")[0]
+            executed_output_str = app.python_repl_utility.run(code_str)
+            try:
+                res = json.loads(executed_output_str)
+                results_store[job_id] = {
+                    "type": "data",
+                    "result_data": res,
+                    "body": openbbchat_output.response,
+                }
+            except Exception as e:
+                results_store[job_id] = {
+                    "type": "data",
+                    "body": f"{openbbchat_output.response}\n\nResult: {executed_output_str}",
+                }
     except Exception as e:
         print(e)
         results_store[job_id] = {

--- a/gptstonks_api/utils.py
+++ b/gptstonks_api/utils.py
@@ -1,5 +1,8 @@
 from typing import List
 
+from langchain.utilities import PythonREPL
+from openbb_chat.kernels.auto_llama_index import AutoLlamaIndex
+
 
 def get_func_parameter_names(func_def: str) -> List[str]:
     # E.g. stocks(symbol: str, time: int) would be ["symbol", "time"]
@@ -107,3 +110,18 @@ def get_default_llm():
 
 def get_keys_file():
     return "./apikeys_list.json"
+
+
+def get_openbb_chat_output(query_str: str, auto_llama_index: AutoLlamaIndex) -> str:
+    nodes = auto_llama_index.retrieve(
+        f"Represent this sentence for searching relevant passages: {query_str}"
+    )
+    return auto_llama_index.synth(query_str, nodes)
+
+
+def get_openbb_chat_output_executed(
+    query_str: str, auto_llama_index: AutoLlamaIndex, python_repl_utility: PythonREPL
+) -> str:
+    output_res = get_openbb_chat_output(query_str, auto_llama_index)
+    code_str = output_res.response.split("```python")[1].split("```")[0]
+    return python_repl_utility.run(code_str)

--- a/pdm.lock
+++ b/pdm.lock
@@ -3,10 +3,9 @@
 
 [metadata]
 groups = ["default"]
-cross_platform = true
-static_urls = false
-lock_version = "4.3"
-content_hash = "sha256:9c7558550609cbc3ff77b9eb73f0ea6bd4e461194b187511fa01e6f6e30b7339"
+strategy = ["cross_platform"]
+lock_version = "4.4"
+content_hash = "sha256:fdaa66f44a4ee5278c70c956eb9ecc68c5b056987fab66bcfcc22c79e5473444"
 
 [[package]]
 name = "accelerate"
@@ -420,6 +419,64 @@ summary = "Fast, simple object-to-object and broadcast signaling"
 files = [
     {file = "blinker-1.6.2-py3-none-any.whl", hash = "sha256:c3d739772abb7bc2860abf5f2ec284223d9ad5c76da018234f6f50d6f31ab1f0"},
     {file = "blinker-1.6.2.tar.gz", hash = "sha256:4afd3de66ef3a9f8067559fb7a1cbe555c17dcbe15971b05d1b625c3e7abe213"},
+]
+
+[[package]]
+name = "brotli"
+version = "1.1.0"
+summary = "Python bindings for the Brotli compression library"
+files = [
+    {file = "Brotli-1.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e1140c64812cb9b06c922e77f1c26a75ec5e3f0fb2bf92cc8c58720dec276752"},
+    {file = "Brotli-1.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c8fd5270e906eef71d4a8d19b7c6a43760c6abcfcc10c9101d14eb2357418de9"},
+    {file = "Brotli-1.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ae56aca0402a0f9a3431cddda62ad71666ca9d4dc3a10a142b9dce2e3c0cda3"},
+    {file = "Brotli-1.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:43ce1b9935bfa1ede40028054d7f48b5469cd02733a365eec8a329ffd342915d"},
+    {file = "Brotli-1.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7c4855522edb2e6ae7fdb58e07c3ba9111e7621a8956f481c68d5d979c93032e"},
+    {file = "Brotli-1.1.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:38025d9f30cf4634f8309c6874ef871b841eb3c347e90b0851f63d1ded5212da"},
+    {file = "Brotli-1.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e6a904cb26bfefc2f0a6f240bdf5233be78cd2488900a2f846f3c3ac8489ab80"},
+    {file = "Brotli-1.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a37b8f0391212d29b3a91a799c8e4a2855e0576911cdfb2515487e30e322253d"},
+    {file = "Brotli-1.1.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:e84799f09591700a4154154cab9787452925578841a94321d5ee8fb9a9a328f0"},
+    {file = "Brotli-1.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f66b5337fa213f1da0d9000bc8dc0cb5b896b726eefd9c6046f699b169c41b9e"},
+    {file = "Brotli-1.1.0-cp310-cp310-win32.whl", hash = "sha256:be36e3d172dc816333f33520154d708a2657ea63762ec16b62ece02ab5e4daf2"},
+    {file = "Brotli-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:0c6244521dda65ea562d5a69b9a26120769b7a9fb3db2fe9545935ed6735b128"},
+    {file = "Brotli-1.1.0.tar.gz", hash = "sha256:81de08ac11bcb85841e440c13611c00b67d3bf82698314928d0b676362546724"},
+]
+
+[[package]]
+name = "brotlicffi"
+version = "1.1.0.0"
+requires_python = ">=3.7"
+summary = "Python CFFI bindings to the Brotli library"
+dependencies = [
+    "cffi>=1.0.0",
+]
+files = [
+    {file = "brotlicffi-1.1.0.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9b7ae6bd1a3f0df532b6d67ff674099a96d22bc0948955cb338488c31bfb8851"},
+    {file = "brotlicffi-1.1.0.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19ffc919fa4fc6ace69286e0a23b3789b4219058313cf9b45625016bf7ff996b"},
+    {file = "brotlicffi-1.1.0.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9feb210d932ffe7798ee62e6145d3a757eb6233aa9a4e7db78dd3690d7755814"},
+    {file = "brotlicffi-1.1.0.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84763dbdef5dd5c24b75597a77e1b30c66604725707565188ba54bab4f114820"},
+    {file = "brotlicffi-1.1.0.0-cp37-abi3-win32.whl", hash = "sha256:1b12b50e07c3911e1efa3a8971543e7648100713d4e0971b13631cce22c587eb"},
+    {file = "brotlicffi-1.1.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:994a4f0681bb6c6c3b0925530a1926b7a189d878e6e5e38fae8efa47c5d9c613"},
+    {file = "brotlicffi-1.1.0.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2e4aeb0bd2540cb91b069dbdd54d458da8c4334ceaf2d25df2f4af576d6766ca"},
+    {file = "brotlicffi-1.1.0.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b7b0033b0d37bb33009fb2fef73310e432e76f688af76c156b3594389d81391"},
+    {file = "brotlicffi-1.1.0.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54a07bb2374a1eba8ebb52b6fafffa2afd3c4df85ddd38fcc0511f2bb387c2a8"},
+    {file = "brotlicffi-1.1.0.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7901a7dc4b88f1c1475de59ae9be59799db1007b7d059817948d8e4f12e24e35"},
+    {file = "brotlicffi-1.1.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ce01c7316aebc7fce59da734286148b1d1b9455f89cf2c8a4dfce7d41db55c2d"},
+    {file = "brotlicffi-1.1.0.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:246f1d1a90279bb6069de3de8d75a8856e073b8ff0b09dcca18ccc14cec85979"},
+    {file = "brotlicffi-1.1.0.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc4bc5d82bc56ebd8b514fb8350cfac4627d6b0743382e46d033976a5f80fab6"},
+    {file = "brotlicffi-1.1.0.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37c26ecb14386a44b118ce36e546ce307f4810bc9598a6e6cb4f7fca725ae7e6"},
+    {file = "brotlicffi-1.1.0.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ca72968ae4eaf6470498d5c2887073f7efe3b1e7d7ec8be11a06a79cc810e990"},
+    {file = "brotlicffi-1.1.0.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:add0de5b9ad9e9aa293c3aa4e9deb2b61e99ad6c1634e01d01d98c03e6a354cc"},
+    {file = "brotlicffi-1.1.0.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9b6068e0f3769992d6b622a1cd2e7835eae3cf8d9da123d7f51ca9c1e9c333e5"},
+    {file = "brotlicffi-1.1.0.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8557a8559509b61e65083f8782329188a250102372576093c88930c875a69838"},
+    {file = "brotlicffi-1.1.0.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a7ae37e5d79c5bdfb5b4b99f2715a6035e6c5bf538c3746abc8e26694f92f33"},
+    {file = "brotlicffi-1.1.0.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:391151ec86bb1c683835980f4816272a87eaddc46bb91cbf44f62228b84d8cca"},
+    {file = "brotlicffi-1.1.0.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:2f3711be9290f0453de8eed5275d93d286abe26b08ab4a35d7452caa1fef532f"},
+    {file = "brotlicffi-1.1.0.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1a807d760763e398bbf2c6394ae9da5815901aa93ee0a37bca5efe78d4ee3171"},
+    {file = "brotlicffi-1.1.0.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa8ca0623b26c94fccc3a1fdd895be1743b838f3917300506d04aa3346fd2a14"},
+    {file = "brotlicffi-1.1.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3de0cf28a53a3238b252aca9fed1593e9d36c1d116748013339f0949bfc84112"},
+    {file = "brotlicffi-1.1.0.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6be5ec0e88a4925c91f3dea2bb0013b3a2accda6f77238f76a34a1ea532a1cb0"},
+    {file = "brotlicffi-1.1.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d9eb71bb1085d996244439154387266fd23d6ad37161f6f52f1cd41dd95a3808"},
+    {file = "brotlicffi-1.1.0.0.tar.gz", hash = "sha256:b77827a689905143f87915310b93b273ab17888fd43ef350d4832c4a71083c13"},
 ]
 
 [[package]]
@@ -894,6 +951,21 @@ summary = "DNS toolkit"
 files = [
     {file = "dnspython-2.4.2-py3-none-any.whl", hash = "sha256:57c6fbaaeaaf39c891292012060beb141791735dbb4004798328fc2c467402d8"},
     {file = "dnspython-2.4.2.tar.gz", hash = "sha256:8dcfae8c7460a2f84b4072e26f1c9f4101ca20c071649cb7c34e8b6a93d58984"},
+]
+
+[[package]]
+name = "duckduckgo-search"
+version = "3.8.1"
+requires_python = ">=3.7"
+summary = "Search for words, documents, images, news, maps and text translation using the DuckDuckGo.com search engine."
+dependencies = [
+    "click>=8.1.3",
+    "httpx[brotli,http2,socks]>=0.24.1",
+    "lxml>=4.9.2",
+]
+files = [
+    {file = "duckduckgo_search-3.8.1-py3-none-any.whl", hash = "sha256:76e8348473802387a7293259a84c993641ce312c20b85d317f60a1a9d43a530e"},
+    {file = "duckduckgo_search-3.8.1.tar.gz", hash = "sha256:20787d8c0d73794b32c4ef18da94b87b53c0275bcaa16d1a028a612949320463"},
 ]
 
 [[package]]
@@ -1387,6 +1459,20 @@ files = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.1.0"
+requires_python = ">=3.6.1"
+summary = "HTTP/2 State-Machine based protocol implementation"
+dependencies = [
+    "hpack<5,>=4.0",
+    "hyperframe<7,>=6.0",
+]
+files = [
+    {file = "h2-4.1.0-py3-none-any.whl", hash = "sha256:03a46bcf682256c95b5fd9e9a99c1323584c3eec6440d379b9903d709476bc6d"},
+    {file = "h2-4.1.0.tar.gz", hash = "sha256:a83aca08fbe7aacb79fec788c9c0bac936343560ed9ec18b82a13a12c28d2abb"},
+]
+
+[[package]]
 name = "hijri-converter"
 version = "2.3.1"
 requires_python = ">=3.7"
@@ -1410,6 +1496,16 @@ dependencies = [
 files = [
     {file = "holidays-0.14.2-py3-none-any.whl", hash = "sha256:441156949b1c41f08bb08ef8e79fcadfd76d2dd7837f49d7bfc6a572fc442c93"},
     {file = "holidays-0.14.2.tar.gz", hash = "sha256:0e70fd174804aea1c870b151319faebcd5cdb0d955b78230434e1afd1778498e"},
+]
+
+[[package]]
+name = "hpack"
+version = "4.0.0"
+requires_python = ">=3.6.1"
+summary = "Pure-Python HPACK header compression"
+files = [
+    {file = "hpack-4.0.0-py3-none-any.whl", hash = "sha256:84a076fad3dc9a9f8063ccb8041ef100867b1878b25ef0ee63847a5d53818a6c"},
+    {file = "hpack-4.0.0.tar.gz", hash = "sha256:fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095"},
 ]
 
 [[package]]
@@ -1444,18 +1540,37 @@ files = [
 
 [[package]]
 name = "httpx"
-version = "0.25.0"
+version = "0.25.1"
 requires_python = ">=3.8"
 summary = "The next generation HTTP client."
 dependencies = [
+    "anyio",
     "certifi",
-    "httpcore<0.19.0,>=0.18.0",
+    "httpcore",
     "idna",
     "sniffio",
 ]
 files = [
-    {file = "httpx-0.25.0-py3-none-any.whl", hash = "sha256:181ea7f8ba3a82578be86ef4171554dd45fec26a02556a744db029a0a27b7100"},
-    {file = "httpx-0.25.0.tar.gz", hash = "sha256:47ecda285389cb32bb2691cc6e069e3ab0205956f681c5b2ad2325719751d875"},
+    {file = "httpx-0.25.1-py3-none-any.whl", hash = "sha256:fec7d6cc5c27c578a391f7e87b9aa7d3d8fbcd034f6399f9f79b45bcc12a866a"},
+    {file = "httpx-0.25.1.tar.gz", hash = "sha256:ffd96d5cf901e63863d9f1b4b6807861dbea4d301613415d9e6e57ead15fc5d0"},
+]
+
+[[package]]
+name = "httpx"
+version = "0.25.1"
+extras = ["brotli", "http2", "socks"]
+requires_python = ">=3.8"
+summary = "The next generation HTTP client."
+dependencies = [
+    "brotli; platform_python_implementation == \"CPython\"",
+    "brotlicffi; platform_python_implementation != \"CPython\"",
+    "h2<5,>=3",
+    "httpx==0.25.1",
+    "socksio==1.*",
+]
+files = [
+    {file = "httpx-0.25.1-py3-none-any.whl", hash = "sha256:fec7d6cc5c27c578a391f7e87b9aa7d3d8fbcd034f6399f9f79b45bcc12a866a"},
+    {file = "httpx-0.25.1.tar.gz", hash = "sha256:ffd96d5cf901e63863d9f1b4b6807861dbea4d301613415d9e6e57ead15fc5d0"},
 ]
 
 [[package]]
@@ -1488,6 +1603,16 @@ dependencies = [
 files = [
     {file = "humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477"},
     {file = "humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc"},
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.0.1"
+requires_python = ">=3.6.1"
+summary = "HTTP/2 framing layer for Python"
+files = [
+    {file = "hyperframe-6.0.1-py3-none-any.whl", hash = "sha256:0ec6bafd80d8ad2195c4f03aacba3a8265e57bc4cff261e802bf39970ed02a15"},
+    {file = "hyperframe-6.0.1.tar.gz", hash = "sha256:ae510046231dc8e9ecb1a6586f63d2347bf4c8905914aa84ba585ae85f28a914"},
 ]
 
 [[package]]
@@ -2911,28 +3036,30 @@ files = [
 
 [[package]]
 name = "openbb-chat"
-version = "0.0.5.post1"
+version = "0.0.6"
 requires_python = ">=3.10"
-summary = "Deep learning package to support the chat interface for OpenBB"
+summary = "Deep learning package to add chat capabilities to OpenBB"
 dependencies = [
     "accelerate>=0.22.0",
     "auto-gptq>=0.4.2",
     "bitsandbytes>=0.41.1",
     "einops>=0.6.1",
     "guidance>=0.0.64",
+    "llama-index>=0.8.20",
     "openbb==3.2.2",
     "optimum>=1.12.0",
     "peft>=0.5.0",
     "pre-commit>=3.3.3",
     "pyrootutils>=1.0.4",
+    "rank-bm25>=0.2.2",
     "rich<13.0.0,>=12.6.0",
     "sentencepiece>=0.1.99",
     "torch==2.*",
     "transformers>=4.33.0",
 ]
 files = [
-    {file = "openbb_chat-0.0.5.post1-py3-none-any.whl", hash = "sha256:70cbfcd6f15c4150ac302bb2e6fe6227bf3174112afba2195953e18ccbbe2488"},
-    {file = "openbb_chat-0.0.5.post1.tar.gz", hash = "sha256:a5dac41ec013a6af460470d50ea6339e3662857cc3eb69f72cd7816e62e10dfb"},
+    {file = "openbb_chat-0.0.6-py3-none-any.whl", hash = "sha256:54d144bc348df398955fd5ab80d28aa6019dc378ff408b206d438362fbcabb82"},
+    {file = "openbb_chat-0.0.6.tar.gz", hash = "sha256:9567e15026efb9a5e3c579b13b90479008b0c045fb9665fb8ddcc814886e6ec2"},
 ]
 
 [[package]]
@@ -3945,6 +4072,18 @@ files = [
 ]
 
 [[package]]
+name = "rank-bm25"
+version = "0.2.2"
+summary = "Various BM25 algorithms for document ranking"
+dependencies = [
+    "numpy",
+]
+files = [
+    {file = "rank_bm25-0.2.2-py3-none-any.whl", hash = "sha256:7bd4a95571adadfc271746fa146a4bcfd89c0cf731e49c3d1ad863290adbe8ae"},
+    {file = "rank_bm25-0.2.2.tar.gz", hash = "sha256:096ccef76f8188563419aaf384a02f0ea459503fdf77901378d4fd9d87e5e51d"},
+]
+
+[[package]]
 name = "rdflib"
 version = "7.0.0"
 requires_python = ">=3.8.1,<4.0.0"
@@ -4313,6 +4452,27 @@ files = [
 ]
 
 [[package]]
+name = "sentence-transformers"
+version = "2.2.2"
+requires_python = ">=3.6.0"
+summary = "Multilingual text embeddings"
+dependencies = [
+    "huggingface-hub>=0.4.0",
+    "nltk",
+    "numpy",
+    "scikit-learn",
+    "scipy",
+    "sentencepiece",
+    "torch>=1.6.0",
+    "torchvision",
+    "tqdm",
+    "transformers<5.0.0,>=4.6.0",
+]
+files = [
+    {file = "sentence-transformers-2.2.2.tar.gz", hash = "sha256:dbc60163b27de21076c9a30d24b5b7b6fa05141d68cf2553fa9a77bf79a29136"},
+]
+
+[[package]]
 name = "sentencepiece"
 version = "0.1.99"
 summary = "SentencePiece python wrapper"
@@ -4441,6 +4601,16 @@ summary = "Sniff out which async library your code is running under"
 files = [
     {file = "sniffio-1.3.0-py3-none-any.whl", hash = "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"},
     {file = "sniffio-1.3.0.tar.gz", hash = "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101"},
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+requires_python = ">=3.6"
+summary = "Sans-I/O implementation of SOCKS4, SOCKS4A, and SOCKS5."
+files = [
+    {file = "socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3"},
+    {file = "socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac"},
 ]
 
 [[package]]
@@ -4848,6 +5018,25 @@ files = [
     {file = "torch-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:0bd691efea319b14ef239ede16d8a45c246916456fa3ed4f217d8af679433cc6"},
     {file = "torch-2.1.0-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:101c139152959cb20ab370fc192672c50093747906ee4ceace44d8dd703f29af"},
     {file = "torch-2.1.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:a6b7438a90a870e4cdeb15301519ae6c043c883fcd224d303c5b118082814767"},
+]
+
+[[package]]
+name = "torchvision"
+version = "0.16.0"
+requires_python = ">=3.8"
+summary = "image and video datasets and models for torch deep learning"
+dependencies = [
+    "numpy",
+    "pillow!=8.3.*,>=5.3.0",
+    "requests",
+    "torch==2.1.0",
+]
+files = [
+    {file = "torchvision-0.16.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:16c300fdbbe91469f5e9feef8d24c6acabd8849db502a06160dd76ba68e897a0"},
+    {file = "torchvision-0.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ef5dec6c48b715353781b83749efcdea03835720a71b377684453ee117aab3c7"},
+    {file = "torchvision-0.16.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:9e3a2012e463f498de21f6598cc7a266b9a8c6fe15788472fdc419233ea6f3f2"},
+    {file = "torchvision-0.16.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:e4327e082b703921ae52caeee4f7839f7e6c73cfc5eedea468ecb5c1487ecdbf"},
+    {file = "torchvision-0.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:62f01513687cce3480df8928fcc6c09b4aa0433d05ac75e82877acc773f6a568"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,10 @@ dependencies = [
     "pre-commit==3.*",
     "pytest==7.*",
     "fastapi==0.*",
-    "openbb-chat>=0.0.5",
+    "openbb-chat>=0.0.6",
     "uvicorn>=0.23.2",
+    "sentence-transformers>=2.2.2",
+    "duckduckgo-search>=3.8.1",
 ]
 requires-python = ">=3.10,<3.11.*"
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 pre-commit==3.*
 pytest==7.*
 fastapi==0.*
-openbb-chat>=0.0.5
+openbb-chat>=0.0.6
 uvicorn>=0.23.2
+sentence-transformers>=2.2.2
+duckduckgo-search>=3.8.1


### PR DESCRIPTION
AutoLlamaIndex uses llama-index for a cleaner and faster retrieval and generation. It provides support for OpenAI models, which are the default ones now in this API. Furthermore, using its capabilities the API has two operating modes: programmer and agent. A field in the post request allows selecting one or the other.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Modifies the API to use AutoLlamaIndex as its engine. It provides higher customization capabilities.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
