### PR TITLE
Add llama.cpp and OpenAI LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Welcome to the GPTStonks Chatbot API documentation! This API allows you to inter
   - [Table of Contents](#table-of-contents)
   - [Introduction 🌟](#introduction-)
   - [Features 🚀](#features-)
+  - [Supported LLM Providers](#supported-llm-providers)
+  - [Supported Embeddings Providers](#supported-embeddings-providers)
   - [Getting Started 🛠️](#getting-started-%EF%B8%8F)
     - [Prerequisites](#prerequisites)
     - [Installation 🛸](#installation-)
@@ -58,6 +60,18 @@ This API allows you to integrate the GPTStonks financial chatbot into your proje
 - **Customizable Responses**: Tailor the chatbot's responses to suit your specific use case.
 - **Easy Integration**: Built on FastAPI, this API is designed for straightforward integration into your application or platform.
 - **Extensive Documentation**: Detailed documentation and examples to help you get started quickly.
+
+## Supported LLM Providers
+
+- **[Llama.cpp](https://github.com/ggerganov/llama.cpp)**: optimized implementations of the most popular open source LLMs for inference over CPU and GPU. See their docs for more details on supported models, which include Mixtral, Llama 2 and Zephyr among others. Many quantized models (GGUF) can be found in Hugging Face under the user [TheBloke](https://huggingface.co/TheBloke).
+- **[Amazon Bedrock](https://aws.amazon.com/bedrock/)**: foundation models from a variety of providers, including Anthropic and Amazon.
+- **[OpenAI](https://platform.openai.com/docs/models)**: GPT family of foundation models. For now only `instruct` versions are supported, such as `gpt-3.5-turbo-instruct`. Chat versions will be added soon.
+- **[Vertex AI](https://cloud.google.com/vertex-ai)**: similar to Amazon Bedrock but provided by Google. This integration is in alpha version, not recommended for now.
+
+## Supported Embeddings Providers
+
+- **[OpenAI Embeddings](https://platform.openai.com/docs/models/embeddings)**: includes models such as Ada 2.
+- **[Hugging Face](https://huggingface.co/)**: including providers such as BAAI, see their general embedding (BGE) [model list](https://huggingface.co/BAAI/bge-large-en-v1.5#model-list).
 
 ## Getting Started 🛠️
 
@@ -113,13 +127,7 @@ docker run -it -p 8000:8000 --env-file .env ghcr.io/gptstonks/api:main
   > openssl.cnf
   ```
 
-  5. Load the environment variables:
-
-  ```bash
-  source .env
-  ```
-
-  6. Start the API:
+  5. Start the API:
 
   ```bash
   uvicorn gptstonks_api.main:app --host 0.0.0.0 --port 8000

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "testing"]
+groups = ["default", "testing", "llamacpp"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:987eb4f857acf9b81f29a0290c099f1f50e1e8eb02663a99e037f05cca47335a"
+content_hash = "sha256:236f9c93e477b0a3f5b050820871b8021c03f4ef279bcde984dc892139e75eee"
 
 [[package]]
 name = "accelerate"
@@ -1077,6 +1077,20 @@ dependencies = [
 files = [
     {file = "langsmith-0.0.69-py3-none-any.whl", hash = "sha256:49a2546bb83eedb0552673cf81a068bb08078d6d48471f4f1018e1d5c6aa46b1"},
     {file = "langsmith-0.0.69.tar.gz", hash = "sha256:8fb5297f274db0576ec650d9bab0319acfbb6622d62bc5bb9fe31c6235dc0358"},
+]
+
+[[package]]
+name = "llama-cpp-python"
+version = "0.2.23"
+requires_python = ">=3.8"
+summary = "Python bindings for the llama.cpp library"
+dependencies = [
+    "diskcache>=5.6.1",
+    "numpy>=1.20.0",
+    "typing-extensions>=4.5.0",
+]
+files = [
+    {file = "llama_cpp_python-0.2.23.tar.gz", hash = "sha256:364b61a13970932ea189b45a1c5dea89797b90e5da00f1fe6e72c47fbc512898"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = ""
 version = ""
-description = "API implementing the endpoints to support GPTStonks Chat"
+description = "GPTStonks API allows interacting with financial data sources using natural language."
 authors = [
     {name = "GPTStonks", email = "gptstonks@gmail.com"},
 ]
@@ -30,6 +30,9 @@ license = {text = "MIT"}
 testing = [
     "pytest",
     "pytest-cov",
+]
+llamacpp = [
+    "llama-cpp-python>=0.2.23",
 ]
 
 # [tool.pdm.resolution.overrides]


### PR DESCRIPTION
 - Llama.cpp allows running open source LLMs locally, over CPU or GPU, in an efficient way.
 - OpenAI is a SOTA provider of LLMs and its integration gives more freedom to users. For now, only `instruct` models can be run with OpenAI.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Integrates OpenAI `instruct` and Llama.cpp models into the API.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
