### PR TITLE
Add multiple node postprocessors

### DIFF
--- a/gptstonks_api/utils.py
+++ b/gptstonks_api/utils.py
@@ -124,11 +124,12 @@ def get_keys_file():
 async def get_openbb_chat_output(
     query_str: str,
     auto_llama_index: AutoLlamaIndex,
-    node_postprocessor: Optional[BaseNodePostprocessor] = None,
+    node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
 ) -> str:
     nodes = await auto_llama_index._retriever.aretrieve(query_str)
-    if node_postprocessor is not None:
-        nodes = node_postprocessor.postprocess_nodes(nodes)
+    if node_postprocessors is not None:
+        for node_postprocessor in node_postprocessors:
+            nodes = node_postprocessor.postprocess_nodes(nodes)
     return await auto_llama_index._query_engine.asynthesize(query_bundle=query_str, nodes=nodes)
 
 
@@ -153,10 +154,10 @@ async def get_openbb_chat_output_executed(
     query_str: str,
     auto_llama_index: AutoLlamaIndex,
     python_repl_utility: PythonREPL,
-    node_postprocessor: Optional[BaseNodePostprocessor] = None,
+    node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
     openbb_pat: Optional[str] = None,
 ) -> str:
-    output_res = await get_openbb_chat_output(query_str, auto_llama_index, node_postprocessor)
+    output_res = await get_openbb_chat_output(query_str, auto_llama_index, node_postprocessors)
     code_str = (
         output_res.response.split("```python")[1].split("```")[0]
         if "```python" in output_res.response


### PR DESCRIPTION
Multiple node postprocessors can now be used instead of just one.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Allows multiple node postprocessors, such as similarity and metadata postprocessors. They are executed in the same order of the list.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
