### PR TITLE
Modify API to work with multiple PATs

### DIFF
--- a/gptstonks_api/utils.py
+++ b/gptstonks_api/utils.py
@@ -130,7 +130,9 @@ async def get_openbb_chat_output(
     if node_postprocessors is not None:
         for node_postprocessor in node_postprocessors:
             nodes = node_postprocessor.postprocess_nodes(nodes)
-    return await auto_llama_index._query_engine.asynthesize(query_bundle=query_str, nodes=nodes)
+    return (
+        await auto_llama_index._query_engine.asynthesize(query_bundle=query_str, nodes=nodes)
+    ).response
 
 
 def fix_frequent_code_errors(prev_code: str, openbb_pat: Optional[str] = None) -> str:
@@ -150,27 +152,26 @@ def fix_frequent_code_errors(prev_code: str, openbb_pat: Optional[str] = None) -
     return prev_code
 
 
-async def get_openbb_chat_output_executed(
-    query_str: str,
-    auto_llama_index: AutoLlamaIndex,
-    python_repl_utility: PythonREPL,
-    node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
-    openbb_pat: Optional[str] = None,
+def run_repl_over_openbb(
+    openbb_chat_output: str, python_repl_utility: PythonREPL, openbb_pat: Optional[str] = None
 ) -> str:
-    output_res = await get_openbb_chat_output(query_str, auto_llama_index, node_postprocessors)
+    if openbb_chat_output.startswith(">") or "```python" not in openbb_chat_output:
+        # already in final response format with context provider added
+        # or no code available to execute
+        return openbb_chat_output
     code_str = (
-        output_res.response.split("```python")[1].split("```")[0]
-        if "```python" in output_res.response
-        else output_res.response
+        openbb_chat_output.split("```python")[1].split("```")[0]
+        if "```python" in openbb_chat_output
+        else openbb_chat_output
     )
     fixed_code_str = fix_frequent_code_errors(code_str, openbb_pat)
     # run Python and get output
     repl_output = python_repl_utility.run(fixed_code_str)
     # get OpenBB's functions called for explicability
-    openbb_funcs_called = []
+    openbb_funcs_called = set()
     for code_line in code_str.split("\n"):
         if "obb." in code_line:
-            openbb_funcs_called.append(code_line.split("obb.")[1].strip())
+            openbb_funcs_called.add(code_line.split("obb.")[1].strip())
     openbb_platform_ref_uri = "https://docs.openbb.co/platform/reference/"
     openbb_funcs_called_str = "".join(
         [
@@ -184,6 +185,17 @@ async def get_openbb_chat_output_executed(
         f"OpenBB's functions called:\n{openbb_funcs_called_str.strip()}\n\n"
         f"```json\n{repl_output.strip()}\n```"
     )
+
+
+async def get_openbb_chat_output_executed(
+    query_str: str,
+    auto_llama_index: AutoLlamaIndex,
+    python_repl_utility: PythonREPL,
+    node_postprocessors: Optional[List[BaseNodePostprocessor]] = None,
+    openbb_pat: Optional[str] = None,
+) -> str:
+    output_res = await get_openbb_chat_output(query_str, auto_llama_index, node_postprocessors)
+    return run_repl_over_openbb(output_res, python_repl_utility, openbb_pat)
 
 
 def run_qa_over_tool_output(tool_input: str | dict, llm: BaseLLM, tool: BaseTool) -> str:

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "testing", "llamacpp"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:31dd54fa964a51e5ffaec391540fb29143b89fceba278045401176a9e05f3dee"
+content_hash = "sha256:0e7bc76e7af14d9ad0f6ce2ffd9c818c951bb0bc025ac3af4b96761e126afce3"
 
 [[package]]
 name = "accelerate"
@@ -2037,6 +2037,19 @@ files = [
 ]
 
 [[package]]
+name = "outcome"
+version = "1.3.0.post0"
+requires_python = ">=3.7"
+summary = "Capture the outcome of Python function calls."
+dependencies = [
+    "attrs>=19.2.0",
+]
+files = [
+    {file = "outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b"},
+    {file = "outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8"},
+]
+
+[[package]]
 name = "packaging"
 version = "23.2"
 requires_python = ">=3.7"
@@ -2443,6 +2456,19 @@ dependencies = [
 files = [
     {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
     {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.23.2"
+requires_python = ">=3.8"
+summary = "Pytest support for asyncio"
+dependencies = [
+    "pytest>=7.0.0",
+]
+files = [
+    {file = "pytest-asyncio-0.23.2.tar.gz", hash = "sha256:c16052382554c7b22d48782ab3438d5b10f8cf7a4bdcae7f0f67f097d95beecc"},
+    {file = "pytest_asyncio-0.23.2-py3-none-any.whl", hash = "sha256:ea9021364e32d58f0be43b91c6233fb8d2224ccef2398d6837559e587682808f"},
 ]
 
 [[package]]
@@ -2869,6 +2895,15 @@ files = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+summary = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.5"
 requires_python = ">=3.8"
@@ -3151,6 +3186,25 @@ dependencies = [
 files = [
     {file = "transformers-4.36.0-py3-none-any.whl", hash = "sha256:e5a9d9424bcbc5008782ddd79ecbc3a50991e168cc730a14c4c89e80c61f419d"},
     {file = "transformers-4.36.0.tar.gz", hash = "sha256:64e120d252db4bdcd355288d19e857dac9d89886f9d0ac20244cb9af3142bb50"},
+]
+
+[[package]]
+name = "trio"
+version = "0.23.2"
+requires_python = ">=3.8"
+summary = "A friendly Python library for async concurrency and I/O"
+dependencies = [
+    "attrs>=20.1.0",
+    "cffi>=1.14; os_name == \"nt\" and implementation_name != \"pypy\"",
+    "exceptiongroup; python_version < \"3.11\"",
+    "idna",
+    "outcome",
+    "sniffio>=1.3.0",
+    "sortedcontainers",
+]
+files = [
+    {file = "trio-0.23.2-py3-none-any.whl", hash = "sha256:5a0b566fa5d50cf231cfd6b08f3b03aa4179ff004b8f3144059587039e2b26d3"},
+    {file = "trio-0.23.2.tar.gz", hash = "sha256:da1d35b9a2b17eb32cae2e763b16551f9aa6703634735024e32f325c9285069e"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ license = {text = "MIT"}
 testing = [
     "pytest",
     "pytest-cov",
+    "trio>=0.23.2",
+    "pytest-asyncio>=0.23.2",
 ]
 llamacpp = [
     "llama-cpp-python>=0.2.23",

--- a/tests/test_multiple_pats.py
+++ b/tests/test_multiple_pats.py
@@ -1,0 +1,36 @@
+import asyncio
+
+import pytest
+from httpx import AsyncClient, codes
+
+from ..gptstonks_api.main import app, init_data
+
+
+async def run_multiple_async_queries():
+    async with AsyncClient(app=app, base_url="http://localhost:8000") as ac:
+        res = await asyncio.gather(
+            *[
+                ac.post(
+                    "/process_query_async",
+                    json={
+                        "query": "get the balance sheets for AAPL",
+                        "use_agent": True,
+                        "openbb_pat": str(i),
+                    },
+                )
+                for i in range(5)
+            ]
+        )
+    return res
+
+
+@pytest.mark.asyncio
+async def test_multiple_pats():
+    try:
+        init_data()
+    except AttributeError as e:
+        pytest.skip("No .env file provided, or not all env variables specified")
+
+    res = await run_multiple_async_queries()
+    for r in res:
+        assert r.status_code == codes.OK


### PR DESCRIPTION
Now the code is executed outside the agent, so that the PAT received in the request can be included in the execution. Previously, the PAT was overrided before it was executed in the agent, which resulted in always using the same PAT when multiple requests arrived at the same time. A test is also added to create the situation where multiple concurrent requests arrive to the API.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Adds concurrency when using PATs by executing the REPL outside the agent. A test is added to easily simulate multiple concurrent requests.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
