### PR TITLE
Update tests to work with importlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ llamacpp = [
 # [tool.pdm.resolution.overrides]
 # Not needed for now
 
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]
 
 [build-system]
 requires = ["pdm-backend"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
-from ..gptstonks_api.main import app
+from gptstonks_api.main import app
 
 client = TestClient(app)
 

--- a/tests/test_multiple_pats.py
+++ b/tests/test_multiple_pats.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 from httpx import AsyncClient, codes
 
-from ..gptstonks_api.main import app, init_data
+from gptstonks_api.main import app, init_data
 
 
 async def run_multiple_async_queries():


### PR DESCRIPTION
__init__.py is removed from the tests folder and the tests are modified to work with relative imports without using `..`.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Updates tests to work without __init__.py, using `importlib` inside pytest.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
