### PR TITLE
Modify agent to generate output instead of the tool

### DIFF
--- a/gptstonks_api/callbacks.py
+++ b/gptstonks_api/callbacks.py
@@ -1,0 +1,21 @@
+from typing import Any, List, Optional
+from uuid import UUID
+
+from langchain.callbacks.base import AsyncCallbackHandler
+from langchain_core.agents import AgentAction
+from pydantic import BaseModel
+
+
+class ToolExecutionOrderCallback(BaseModel, AsyncCallbackHandler):
+    tools_used: list[str] = []
+
+    async def on_agent_action(
+        self,
+        action: AgentAction,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.tools_used.append(action.tool)

--- a/gptstonks_api/explicability.py
+++ b/gptstonks_api/explicability.py
@@ -1,0 +1,13 @@
+def add_context_to_output(output: str, tools_executed: list[str]) -> str:
+    openbb_context = "> Context retrieved using OpenBB."
+    complete_context = (
+        f"> Context retrieved using {','.join(tools_executed)}."
+        if len(tools_executed) > 0
+        else "> Answer generated with the AI's own knowledge."
+    )
+
+    return (
+        output.replace(openbb_context, complete_context)
+        if openbb_context in output
+        else f"{complete_context}\n\n{output}"
+    )

--- a/gptstonks_api/utils.py
+++ b/gptstonks_api/utils.py
@@ -153,9 +153,8 @@ def fix_frequent_code_errors(prev_code: str, openbb_pat: Optional[str] = None) -
 def run_repl_over_openbb(
     openbb_chat_output: str, python_repl_utility: PythonREPL, openbb_pat: Optional[str] = None
 ) -> str:
-    if openbb_chat_output.startswith(">") or "```python" not in openbb_chat_output:
-        # already in final response format with context provider added
-        # or no code available to execute
+    if "```python" not in openbb_chat_output:
+        # no code available to execute
         return openbb_chat_output
     code_str = (
         openbb_chat_output.split("```python")[1].split("```")[0]


### PR DESCRIPTION
The return direct is removed in those tools that allow it, such as DDG Search. Thus, the agent can generate the response based on the original query or even call another tool if appropriate.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Modify the tool structure to not return directly and include a callback to retrieve tool execution order for explicability.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
