### PR TITLE
Add Docker releases when a version tag is pushed

### DIFF
--- a/.github/workflows/docker-versions.yaml
+++ b/.github/workflows/docker-versions.yaml
@@ -1,8 +1,8 @@
-name: "Docker build and push"
+name: "Docker build and push when new version is available"
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "*.*.*"
 
 env:
   REGISTRY: ghcr.io
@@ -12,7 +12,7 @@ jobs:
   docker-build-ghcr:
     name: "Build and push Docker image to ghcr.io"
     runs-on: ubuntu-latest
-
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -44,6 +44,10 @@ jobs:
 
       - name: Checkout repository to build machine
         uses: actions/checkout@v2
+
+      - name: Set tag as output variable
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       - name: Log in to the ghcr.io
         uses: docker/login-action@v2
@@ -68,13 +72,13 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ steps.meta_ghcr.outputs.tags }}
+          tags: ${{ steps.vars.outputs.tag }}
           labels: ${{ steps.meta_ghcr.outputs.labels }}
 
   docker-build-hub:
     name: "Build and push Docker image to Docker Hub"
     runs-on: ubuntu-latest
-
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -107,6 +111,10 @@ jobs:
       - name: Checkout repository to build machine
         uses: actions/checkout@v2
 
+      - name: Set tag as output variable
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -125,5 +133,5 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ steps.meta_dockerhub.outputs.tags }}
+          tags: ${{ steps.vars.outputs.tag }}
           labels: ${{ steps.meta_dockerhub.outputs.labels }}


### PR DESCRIPTION
The releases are pushed to ghcr.io and Docker Hub with the version tag. The original Docker push in main is also modified to remove a deprecated variable that is no longer used.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Adds workflow to push Docker versions as releases.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
