### PR TITLE
Modify docker compose to make LOCAL_LLM_PATH optional

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     env_file:
       - .env.template
     volumes:
-      - ${LOCAL_LLM_PATH}:/api/gptstonks_api/zephyr-7b-beta.Q4_K_M.gguf
+      - ${LOCAL_LLM_PATH:-/dev/null}:/api/gptstonks_api/zephyr-7b-beta.Q4_K_M.gguf
 
   frontend:
     image: gptstonks/front-end:latest


### PR DESCRIPTION
LOCAL_LLM_PATH is only needed for Llama.cpp, so it is made optional as it is not used for most providers.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

Improves the Docker Compose so that the LOCAL_LLM_PATH env variable is not included by default. It is only needed for Llama.cpp's GGUF models.

## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally** with `pytest` command?
- [x] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
